### PR TITLE
fix / subfolder clickable

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Ura/sparqlist"]
 	path = Ura/sparqlist
-	url = github_Ningensei848:Ningensei848/sparqlist.git
+	url = https://github.com/Ningensei848/sparqlist.git
 [submodule "Omote/metastanza"]
 	path = Omote/metastanza
-	url = github_Ningensei848:Ningensei848/metastanza.git
+	url = https://github.com/Ningensei848/metastanza


### PR DESCRIPTION
If we use ssh method for `.gitmodules` URL, the link of submodule folder is invalid (not detected by github).

I changed the URL to HTTPS so that the link to be clickable.

---

`.gitmodules` のURLをssh方式にしていると，submodule フォルダのリンクが無効になる（github側で検出できない）．

URLをHTTPS方式に変更し，リンクをクリック可能なものに変更した．